### PR TITLE
Add Hover Lift & Transition Styling to Cards Under “Why learn Java with Javaistic?”

### DIFF
--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -58,7 +58,7 @@ export default function HomePage() {
 
         {/* Section: Docs */}
         <article className="mx-auto mb-10 sm:space-x-10 flex flex-col items-center py-10 sm:flex-row">
-          <div className="w-full sm:w-1/2">
+          <div className="w-full sm:w-1/2 transition-transform duration-300 hover:-translate-y-2 hover:scale-105">
             <Image
               src="/img/home/docs.svg"
               alt="Javaistic Docs"
@@ -111,7 +111,7 @@ export default function HomePage() {
               </Button>
             </Link>
           </div>
-          <div className="w-full sm:w-1/2">
+          <div className="w-full sm:w-1/2 transition-transform duration-300 hover:-translate-y-2 hover:scale-105">
             <Image
               src="/img/home/programs.svg"
               alt="Javaistic Programs"
@@ -127,7 +127,7 @@ export default function HomePage() {
 
         {/* Section: GitHub */}
         <article className="flex flex-col sm:flex-row items-center py-14 space-y-10 sm:space-y-0 sm:space-x-10">
-          <div className="w-full sm:w-1/2">
+          <div className="w-full sm:w-1/2 transition-transform duration-300 hover:-translate-y-2 hover:scale-105">
             <Image
               src="/img/home/open-source.svg"
               alt="Javaistic GitHub"


### PR DESCRIPTION
 Issue #731  Resolved

**What was before?**


<img width="1875" height="848" alt="image" src="https://github.com/user-attachments/assets/1a9f13f5-e50a-4a37-ab87-e6a49dd960ce" />


Previously, the three key sections under Why learn Java with Javaistic? Docs, Coding, and GitHub had static images with no interactivity or hover animation. The layout was clean but felt a bit flat in terms of user experience.

**What I changed**

I added a subtle 3D transform hover effect to the feature images using Tailwind classes and a custom transition.

<img width="1824" height="839" alt="image" src="https://github.com/user-attachments/assets/ee7b604c-f55f-4472-a98b-ffb72ca73ad2" />

Here’s what happens now:

- When a user hovers over any image, it gently lifts upward and scales slightly.

- This gives a modern, engaging, and dynamic feel especially useful for attracting beginner users and improving interaction time.


**Why this change?**

- Makes the site feel more lively and premium.

- Adds a micro-interaction without compromising performance or layout.


- Keeps the user more engaged and improves perceived responsiveness.

**Outcome**

✅ The layout remains exactly the same

✅ Mobile and tablet compatibility preserved

✅ Now feels more interactive and user-friendly